### PR TITLE
fix: Correct typo in Websockets label

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 - [ ] Timesheets
 - [ ] Toast notifications
 - [ ] Realtime updates
-- [ ] Websockets???
+- [ ] Websockets???????
 - [ ] App updates with git hash versioning
 
 ---


### PR DESCRIPTION
Fixed a typo in the label for Websockets to ensure consistency in the project.